### PR TITLE
20 LTS compatible

### DIFF
--- a/Project/Sources/Classes/_modernize.4dm
+++ b/Project/Sources/Classes/_modernize.4dm
@@ -8,8 +8,10 @@ Class constructor
 	// Replace declaration lines using the old “(_o_)C_xxx(...)” syntax with the new one “var ... : type”.
 Function C_2var() : Boolean
 	
-	var $pattern : Text:="(?-msi)(?<!//)(?<!//\\s){C_}\\((?![\\w\\s]+;\\s*\\$\\{?\\d+\\}?)([^{\\)]*)\\)"
-	var $code : Text:=This:C1470.fullMethodText
+	var $pattern : Text
+	$pattern:="(?-msi)(?<!//)(?<!//\\s){C_}\\((?![\\w\\s]+;\\s*\\$\\{?\\d+\\}?)([^{\\)]*)\\)"
+	var $code : Text
+	$code:=This:C1470.fullMethodText
 	
 	This:C1470.rgx.setTarget($code)
 	

--- a/Project/Sources/Classes/_regex.4dm
+++ b/Project/Sources/Classes/_regex.4dm
@@ -120,6 +120,7 @@ Function setPattern($pattern : Text) : cs:C1710._regex
 Function match($start; $all : Boolean) : Boolean
 	
 	var $i; $index : Integer
+	var $substring : Text
 	
 	ARRAY LONGINT:C221($pos; 0)
 	ARRAY LONGINT:C221($len; 0)
@@ -157,9 +158,10 @@ Function match($start; $all : Boolean) : Boolean
 				
 				For ($i; 0; Size of array:C274($pos); 1)
 					
+					$substring:=Substring:C12(This:C1470._target; $pos{$i}; $len{$i})
 					This:C1470.matches.push({\
 						index: $index; \
-						data: Substring:C12(This:C1470._target; $pos{$i}; $len{$i}); \
+						data: $substring; \
 						position: $pos{$i}; \
 						length: $len{$i}\
 						})
@@ -212,6 +214,7 @@ Function match($start; $all : Boolean) : Boolean
 Function extract($groups) : Collection
 	
 	var $i; $index; $indx : Integer
+	var $substring : Text
 	
 	This:C1470._init()
 	
@@ -288,9 +291,10 @@ Function extract($groups) : Collection
 							
 							If (This:C1470.matches.query("data = :1 & pos = :2"; Substring:C12(This:C1470._target; $pos{$i}; $len{$i}); $pos{$i}).pop()=Null:C1517)
 								
+								$substring:=Substring:C12(This:C1470._target; $pos{$i}; $len{$i})
 								This:C1470.matches.push({\
 									index: $indx; \
-									data: Substring:C12(This:C1470._target; $pos{$i}; $len{$i}); \
+									data: $substring; \
 									pos: $pos{$i}; \
 									len: $len{$i}\
 									})
@@ -332,7 +336,7 @@ Function extract($groups) : Collection
 	// Replace matching substrings with the replacement text.
 Function substitute($replacement : Text; $count : Integer; $position : Integer) : Text
 	
-	var $replacedText : Text
+	var $replacedText; $substring : Text
 	var $i; $index : Integer
 	var $o : Object
 	
@@ -381,10 +385,10 @@ Function substitute($replacement : Text; $count : Integer; $position : Integer) 
 					End if 
 					
 					If ($match)
-						
+						$substring:=Substring:C12(This:C1470._target; $pos{$i}; $len{$i})
 						This:C1470.matches.push({\
 							index: $index; \
-							data: Substring:C12(This:C1470._target; $pos{$i}; $len{$i}); \
+							data: $substring; \
 							pos: $pos{$i}; \
 							len: $len{$i}; \
 							_subpattern: $sub\

--- a/Project/Sources/Classes/_regex.4dm
+++ b/Project/Sources/Classes/_regex.4dm
@@ -147,8 +147,8 @@ Function match($start; $all : Boolean) : Boolean
 	
 	Repeat 
 		
-		var $match : Boolean:=Try(Match regex:C1019(This:C1470._pattern; This:C1470._target; $start; $pos; $len))
-		
+		var $match : Boolean
+		$match:=Match regex:C1019(This:C1470._pattern; This:C1470._target; $start; $pos; $len)
 		If (Last errors:C1799.length=0)
 			
 			If ($match)
@@ -260,11 +260,13 @@ Function extract($groups) : Collection
 	ARRAY LONGINT:C221($len; 0)
 	ARRAY LONGINT:C221($pos; 0)
 	
-	var $start : Integer:=1
+	var $start : Integer
+	$start:=1
 	
 	Repeat 
 		
-		var $match : Boolean:=Try(Match regex:C1019(This:C1470._pattern; This:C1470._target; $start; $pos; $len))
+		var $match : Boolean
+		$match:=Match regex:C1019(This:C1470._pattern; This:C1470._target; $start; $pos; $len)
 		
 		If (Last errors:C1799.length=0)
 			
@@ -272,11 +274,12 @@ Function extract($groups) : Collection
 				
 				This:C1470.success:=True:C214
 				
-				var $current : Integer:=0
-				
+				var $current : Integer
+				$current:=0
 				For ($i; 0; Size of array:C274($pos); 1)
 					
-					var $groupIndex : Integer:=$groups.length>0 ? $groups.indexOf(String:C10($current)) : $current
+					var $groupIndex : Integer
+					$groupIndex:=$groups.length>0 ? $groups.indexOf(String:C10($current)) : $current
 					
 					If ($groupIndex>=0)
 						
@@ -338,21 +341,25 @@ Function substitute($replacement : Text; $count : Integer; $position : Integer) 
 	
 	// TODO:Manage count and position
 	
-	var $backup : Text:=$replacement
+	var $backup : Text
+	$backup:=$replacement
 	
 	This:C1470._init()
 	
-	var $start : Integer:=1
+	var $start : Integer
+	$start:=1
 	
 	Repeat 
 		
-		var $match : Boolean:=Try(Match regex:C1019(This:C1470._pattern; This:C1470._target; $start; $pos; $len))
+		var $match : Boolean
+		$match:=Match regex:C1019(This:C1470._pattern; This:C1470._target; $start; $pos; $len)
 		
 		If (Last errors:C1799.length=0)
 			
 			If ($match)
 				
-				var $sub : Integer:=0
+				var $sub : Integer
+				$sub:=0
 				
 				For ($i; 0; Size of array:C274($pos); 1)
 					
@@ -415,7 +422,8 @@ Function substitute($replacement : Text; $count : Integer; $position : Integer) 
 			
 			If ($o._subpattern#0)
 				
-				var $subexpression : Text:="\\"+String:C10($o._subpattern)
+				var $subexpression : Text
+				$subexpression:="\\"+String:C10($o._subpattern)
 				
 				If (Position:C15($subexpression; $replacement)>0)
 					
@@ -454,7 +462,8 @@ Function lookingAt() : Boolean
 	
 	This:C1470._init()
 	
-	var $match : Boolean:=Try(Match regex:C1019(This:C1470._pattern; This:C1470._target; 1; *))
+	var $match : Boolean
+	$match:=Match regex:C1019(This:C1470._pattern; This:C1470._target; 1; *)
 	This:C1470.success:=(Last errors:C1799.length=0) && ($match)
 	
 	This:C1470.searchTime:=This:C1470._elapsedTime()

--- a/Project/Sources/Classes/macros.4dm
+++ b/Project/Sources/Classes/macros.4dm
@@ -139,7 +139,7 @@ Function tokenise()
 	
 	For ($process; 1; Count tasks:C335; 1)
 		
-		Try(_O_PROCESS PROPERTIES:C336($process; $name; $state; $time; $mode; $UID; $origin))
+		PROCESS PROPERTIES:C336($process; $name; $state; $time; $mode; $UID; $origin)
 		
 		If ($origin=Design process:K36:9)
 			
@@ -157,7 +157,8 @@ If not, suggest to create it.
 */
 Function test_macro() : Boolean
 	
-	var $t : Text:="test_macro"
+	var $t : Text
+	$t:="test_macro"
 	
 	ARRAY TEXT:C222($_t; 0)
 	METHOD GET NAMES:C1166($_t; $t; *)

--- a/Project/Sources/Classes/macros.4dm
+++ b/Project/Sources/Classes/macros.4dm
@@ -165,7 +165,7 @@ Function test_macro() : Boolean
 	
 	If (Size of array:C274($_t)>0)
 		
-		return Formula from string:C1601($t; sk execute in host database:K88:5).call()
+		return Formula from string:C1601($t).call()
 		
 	Else 
 		

--- a/Project/Sources/Methods/_MACROS.4dm
+++ b/Project/Sources/Methods/_MACROS.4dm
@@ -2,7 +2,8 @@
 #DECLARE($action : Text)
 
 var $success : Boolean
-var $macro : cs:C1710.macros:=cs:C1710.macros.new()
+var $macro : cs:C1710.macros
+$macro:=cs:C1710.macros.new()
 
 If (OB Instance of:C1731($macro[$action]; 4D:C1709.Function))
 	

--- a/Project/Sources/Methods/test_macro.4dm
+++ b/Project/Sources/Methods/test_macro.4dm
@@ -7,8 +7,8 @@ GET MACRO PARAMETER:C997(Full method text:K5:17; $fullMethod)
 var $highlighted
 GET MACRO PARAMETER:C997(Highlighted method text:K5:18; $highlighted)
 
-var $withSelection : Boolean:=Length:C16($highlighted)>0
-
+var $withSelection : Boolean
+$withSelection:=Length:C16($highlighted)>0
 
 // YOUR CODE HERE
 


### PR DESCRIPTION
Hi! I've noticed the macro not working on 4D 20.1 LTS and thought to make it compatible.
I don't know if it is wanted/needed but since I did the work anyway, I thought to open a pull request.

As seen in the last commit, I had to remove the 'sk execute in host database' from the 'Formula from string' command to make it compatible. I had no issues in executing the Macro after this, but it might change the behaviour of testing in a negative way. Since I do not know what the function does exactly, I could replace it with something else and/or test it properly, Sorry about that.

Let me know what you think!